### PR TITLE
Remove Elixir 1.3 warnings

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "{config,lib,test,mix}/**/*.{ex,exs}"],
+  locals_without_parens: [docp: 1, defparsec: 2, defparsec: 3]
+]

--- a/lib/float_pp.ex
+++ b/lib/float_pp.ex
@@ -69,8 +69,12 @@ defmodule FloatPP do
   """
   def to_iodata(float, options \\ %{}) when is_float(float) do
     options = Map.merge(%{compact: false, rounding: :half_even}, options)
-    if not(Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)), do:
-      options = Map.put(options, :decimals, true)
+    
+    options = if not(Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)) do 
+                Map.put(options, :decimals, true)
+              else
+                options
+              end
 
     {digits, place, positive} = FloatPP.Digits.to_digits(float)
 
@@ -84,8 +88,9 @@ defmodule FloatPP do
   # Take our list of integers and convert to a list of strings
   defp stringify({digits, place, positive}) do
     digit_string = digits
-                    |> List.flatten
-                    |> Enum.map(&Integer.to_string/1)
+    |> List.flatten
+    |> Enum.map(&Integer.to_string/1)
+    
     {digit_string, place, positive}
   end
 
@@ -126,15 +131,18 @@ defmodule FloatPP do
     digit_count = Enum.count(digits)
 
     needed = place + max(1, decimals)
-    if digit_count < needed do
-      digits = digits ++ List.duplicate("0", needed - digit_count)
-    end
+    digits =  if digit_count < needed do
+                digits ++ List.duplicate("0", needed - digit_count)
+              else
+                digits
+              end
 
     # Ensure we have enough zeros on each end to place the "."
-    if place <= 0 do
-      digits = List.duplicate("0", 1 - place) ++ digits
-      place = 1
-    end
+    {digits, place} = if place <= 0 do
+                        {List.duplicate("0", 1 - place) ++ digits, 1}
+                      else
+                        {digits, place}
+                      end
 
     # Split the digits and place the decimal in the correct place
     {l, r} = Enum.split(digits, place)
@@ -143,7 +151,7 @@ defmodule FloatPP do
   end
 
 
-  @doc """
+  @docp """
   Format an exponent in float point format
 
     iex> format_exponent(4)

--- a/lib/float_pp.ex
+++ b/lib/float_pp.ex
@@ -69,8 +69,8 @@ defmodule FloatPP do
   """
   def to_iodata(float, options \\ %{}) when is_float(float) do
     options = Map.merge(%{compact: false, rounding: :half_even}, options)
-    
-    options = if not(Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)) do 
+
+    options = if not(Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)) do
                 Map.put(options, :decimals, true)
               else
                 options
@@ -90,7 +90,7 @@ defmodule FloatPP do
     digit_string = digits
     |> List.flatten
     |> Enum.map(&Integer.to_string/1)
-    
+
     {digit_string, place, positive}
   end
 
@@ -151,7 +151,7 @@ defmodule FloatPP do
   end
 
 
-  @docp """
+  _ = """
   Format an exponent in float point format
 
     iex> format_exponent(4)

--- a/lib/float_pp.ex
+++ b/lib/float_pp.ex
@@ -51,14 +51,13 @@ defmodule FloatPP do
     "12.3456"
   """
 
-
   @doc """
   Convert a float to the shortest, correctly rounded string that converts to the
   same float when read back with String.to_float
   """
   def to_string(float, options \\ %{}) when is_float(float) do
     to_iodata(float, options)
-    |> IO.iodata_to_binary
+    |> IO.iodata_to_binary()
   end
 
   @doc """
@@ -70,11 +69,12 @@ defmodule FloatPP do
   def to_iodata(float, options \\ %{}) when is_float(float) do
     options = Map.merge(%{compact: false, rounding: :half_even}, options)
 
-    options = if not(Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)) do
-                Map.put(options, :decimals, true)
-              else
-                options
-              end
+    options =
+      if not (Map.has_key?(options, :decimals) or Map.has_key?(options, :scientific)) do
+        Map.put(options, :decimals, true)
+      else
+        options
+      end
 
     {digits, place, positive} = FloatPP.Digits.to_digits(float)
 
@@ -84,32 +84,31 @@ defmodule FloatPP do
     |> format_decimal(options)
   end
 
-
   # Take our list of integers and convert to a list of strings
   defp stringify({digits, place, positive}) do
-    digit_string = digits
-    |> List.flatten
-    |> Enum.map(&Integer.to_string/1)
+    digit_string =
+      digits
+      |> List.flatten()
+      |> Enum.map(&Integer.to_string/1)
 
     {digit_string, place, positive}
   end
-
 
   # Prepend a "-" if not (positive)
   defp add_negative_sign(digits, _positive = true), do: digits
   defp add_negative_sign(digits, _positive = false), do: ["-" | digits]
 
-
   # format as a decimal number, either: decimal, or scientific notation
   # optionally will pad out decimal places to given "dp" if given option
   # compact: false
   # Returns iodata list
-  def format_decimal({digits, place, positive}, %{scientific: dp, compact: false}) when is_integer(dp) do
-    [do_format_decimal({digits, 1, positive}, dp), format_exponent(place-1)]
+  def format_decimal({digits, place, positive}, %{scientific: dp, compact: false})
+      when is_integer(dp) do
+    [do_format_decimal({digits, 1, positive}, dp), format_exponent(place - 1)]
   end
 
   def format_decimal({digits, place, positive}, %{scientific: _dp}) do
-    [do_format_decimal({digits, 1, positive}, 0), format_exponent(place-1)]
+    [do_format_decimal({digits, 1, positive}, 0), format_exponent(place - 1)]
   end
 
   def format_decimal(digits_t, %{decimals: dp, compact: false}) when is_integer(dp) do
@@ -119,7 +118,6 @@ defmodule FloatPP do
   def format_decimal(digits_t, _options) do
     do_format_decimal(digits_t, 0)
   end
-
 
   # Insert a decimal in the given location
   # Optionally ensure we have "decimals" places of precision
@@ -131,25 +129,28 @@ defmodule FloatPP do
     digit_count = Enum.count(digits)
 
     needed = place + max(1, decimals)
-    digits =  if digit_count < needed do
-                digits ++ List.duplicate("0", needed - digit_count)
-              else
-                digits
-              end
+
+    digits =
+      if digit_count < needed do
+        digits ++ List.duplicate("0", needed - digit_count)
+      else
+        digits
+      end
 
     # Ensure we have enough zeros on each end to place the "."
-    {digits, place} = if place <= 0 do
-                        {List.duplicate("0", 1 - place) ++ digits, 1}
-                      else
-                        {digits, place}
-                      end
+    {digits, place} =
+      if place <= 0 do
+        {List.duplicate("0", 1 - place) ++ digits, 1}
+      else
+        {digits, place}
+      end
 
     # Split the digits and place the decimal in the correct place
     {l, r} = Enum.split(digits, place)
+
     [l, decimal_sym, r]
     |> add_negative_sign(positive)
   end
-
 
   _ = """
   Format an exponent in float point format
@@ -161,9 +162,9 @@ defmodule FloatPP do
     iex> format_exponent(-128)
       e-128
   """
-  defp format_exponent(exp) when (abs(exp) < 10) and (exp >= 0), do: ["e+0", Integer.to_string(exp)]
-  defp format_exponent(exp) when (abs(exp) < 10), do: ["e-0", Integer.to_string(-exp)]
-  defp format_exponent(exp) when (exp < 0), do: ["e-", Integer.to_string(-exp)]
-  defp format_exponent(exp), do: ["e+", Integer.to_string(exp)]
 
+  defp format_exponent(exp) when abs(exp) < 10 and exp >= 0, do: ["e+0", Integer.to_string(exp)]
+  defp format_exponent(exp) when abs(exp) < 10, do: ["e-0", Integer.to_string(-exp)]
+  defp format_exponent(exp) when exp < 0, do: ["e-", Integer.to_string(-exp)]
+  defp format_exponent(exp), do: ["e+", Integer.to_string(exp)]
 end

--- a/lib/float_pp/round.ex
+++ b/lib/float_pp/round.ex
@@ -26,14 +26,14 @@ defmodule FloatPP.Round do
   """
   require Integer
 
-  @type rounding :: :down |
-                    :half_up |
-                    :half_even |
-                    :ceiling |
-                    :floor |
-                    :half_down |
-                    :up
-
+  @type rounding ::
+          :down
+          | :half_up
+          | :half_even
+          | :ceiling
+          | :floor
+          | :half_down
+          | :up
 
   @doc """
   Round a digit using a specified rounding.
@@ -76,20 +76,25 @@ defmodule FloatPP.Round do
     do: do_round(digits_t, dp + place - 1, options)
 
   defp do_round({digits, place, positive}, round_at, %{rounding: rounding}) do
-      case Enum.split(digits, round_at) do
-        {l, [least_sig | [tie | rest]]} ->
-          case do_incr(l, least_sig, increment?(positive, least_sig, tie, rest, rounding)) do
-            [:rollover | digits] -> {digits, place + 1, positive}
-            digits               -> {digits, place, positive}
-          end
-        {[] = l, [least_sig | []]} ->
-          case do_incr(l, least_sig, increment?(positive, least_sig, 0, [], rounding)) do
-            [:rollover | digits] -> {digits, place + 1, positive}
-            digits               -> {digits, place, positive}
-          end
-        {l, [least_sig | []]}    -> {[l, least_sig], place, positive}
-        {l, []}                  -> {l, place, positive}
-      end
+    case Enum.split(digits, round_at) do
+      {l, [least_sig | [tie | rest]]} ->
+        case do_incr(l, least_sig, increment?(positive, least_sig, tie, rest, rounding)) do
+          [:rollover | digits] -> {digits, place + 1, positive}
+          digits -> {digits, place, positive}
+        end
+
+      {[] = l, [least_sig | []]} ->
+        case do_incr(l, least_sig, increment?(positive, least_sig, 0, [], rounding)) do
+          [:rollover | digits] -> {digits, place + 1, positive}
+          digits -> {digits, place, positive}
+        end
+
+      {l, [least_sig | []]} ->
+        {[l, least_sig], place, positive}
+
+      {l, []} ->
+        {l, place, positive}
+    end
   end
 
   defp do_incr(l, least_sig, false), do: [l, least_sig]
@@ -97,18 +102,23 @@ defmodule FloatPP.Round do
   # else need to cascade the increment
   defp do_incr(l, 9, true) do
     l
-    |> Enum.reverse
+    |> Enum.reverse()
     |> cascade_incr
     |> Enum.reverse([0])
   end
 
   # cascade an increment of decimal digits which could be rolling over 9 -> 0
   defp cascade_incr([9 | rest]), do: [0 | cascade_incr(rest)]
-  defp cascade_incr([d | rest]), do: [d+1 | rest]
+  defp cascade_incr([d | rest]), do: [d + 1 | rest]
   defp cascade_incr([]), do: [1, :rollover]
 
-
-  @spec increment?(boolean, non_neg_integer | nil, non_neg_integer | nil, list, FloatPP.rounding) :: boolean
+  @spec increment?(
+          boolean,
+          non_neg_integer | nil,
+          non_neg_integer | nil,
+          list,
+          FloatPP.rounding()
+        ) :: boolean
   defp increment?(positive, least_sig, tie, rest, round)
 
   # Directed rounding towards 0 (truncate)

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,15 @@ defmodule Float.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :float,
-     version: "0.8.0",
-     elixir: "~> 1.0",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     package: package()]
+    [
+      app: :float,
+      version: "0.8.0",
+      elixir: "~> 1.0",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      package: package()
+    ]
   end
 
   # Configuration for the OTP application
@@ -32,9 +34,11 @@ defmodule Float.Mixfile do
   end
 
   defp package do
-    [files: ~w(lib mix.exs README.md LICENSE),
-     contributors: ["Ed Wildgoose"],
-     licenses: ["Apache 2.0"],
-     links: %{"GitHub" => "https://github.com/ewildgoose/elixir-float_pp"}]
+    [
+      files: ~w(lib mix.exs README.md LICENSE),
+      contributors: ["Ed Wildgoose"],
+      licenses: ["Apache 2.0"],
+      links: %{"GitHub" => "https://github.com/ewildgoose/elixir-float_pp"}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Float.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   # Configuration for the OTP application

--- a/test/float_pp_digits_test.exs
+++ b/test/float_pp_digits_test.exs
@@ -1,7 +1,6 @@
 defmodule FloatPP.DigitsTest do
   use ExUnit.Case
 
-
   test "test to_digits(zero)" do
     assert {[0], 1, true} == FloatPP.Digits.to_digits(0.0)
   end
@@ -16,28 +15,35 @@ defmodule FloatPP.DigitsTest do
 
   test "test to_digits(small denormalized number)" do
     # 4.94065645841246544177e-324
-    <<small_denorm::float>> = <<0,0,0,0,0,0,0,1>>
-    assert {[4, 9, 4, 0, 6, 5, 6, 4, 5, 8, 4, 1, 2, 4, 6, 5, 4], -323, true} == FloatPP.Digits.to_digits(small_denorm)
+    <<small_denorm::float>> = <<0, 0, 0, 0, 0, 0, 0, 1>>
+
+    assert {[4, 9, 4, 0, 6, 5, 6, 4, 5, 8, 4, 1, 2, 4, 6, 5, 4], -323, true} ==
+             FloatPP.Digits.to_digits(small_denorm)
   end
 
   test "test to_digits(large denormalized number)" do
     # 2.22507385850720088902e-308
-    <<large_denorm::float>> = <<0,15,255,255,255,255,255,255>>
-    assert {[2, 2, 2, 5, 0, 7, 3, 8, 5, 8, 5, 0, 7, 2, 0, 1], -307, true} == FloatPP.Digits.to_digits(large_denorm)
+    <<large_denorm::float>> = <<0, 15, 255, 255, 255, 255, 255, 255>>
+
+    assert {[2, 2, 2, 5, 0, 7, 3, 8, 5, 8, 5, 0, 7, 2, 0, 1], -307, true} ==
+             FloatPP.Digits.to_digits(large_denorm)
   end
 
   test "test to_digits(small normalized number)" do
     # 2.22507385850720138309e-308
-    <<small_norm::float>> = <<0,16,0,0,0,0,0,0>>
-    assert {[2, 2, 2, 5, 0, 7, 3, 8, 5, 8, 5, 0, 7, 2, 0, 1, 4], -307, true} == FloatPP.Digits.to_digits(small_norm)
+    <<small_norm::float>> = <<0, 16, 0, 0, 0, 0, 0, 0>>
+
+    assert {[2, 2, 2, 5, 0, 7, 3, 8, 5, 8, 5, 0, 7, 2, 0, 1, 4], -307, true} ==
+             FloatPP.Digits.to_digits(small_norm)
   end
 
   test "test to_digits(large normalized number)" do
     # 1.79769313486231570815e+308
-    <<large_norm::float>> = <<127,239,255,255,255,255,255,255>>
-    assert {[1, 7, 9, 7, 6, 9, 3, 1, 3, 4, 8, 6, 2, 3, 1, 5, 7], 309, true} == FloatPP.Digits.to_digits(large_norm)
-  end
+    <<large_norm::float>> = <<127, 239, 255, 255, 255, 255, 255, 255>>
 
+    assert {[1, 7, 9, 7, 6, 9, 3, 1, 3, 4, 8, 6, 2, 3, 1, 5, 7], 309, true} ==
+             FloatPP.Digits.to_digits(large_norm)
+  end
 
   ############################################################################
   # test frexp/1
@@ -57,27 +63,25 @@ defmodule FloatPP.DigitsTest do
 
   test "test frexp(small denormalized number)" do
     # 4.94065645841246544177e-324
-    <<small_denorm::float>> = <<0,0,0,0,0,0,0,1>>
+    <<small_denorm::float>> = <<0, 0, 0, 0, 0, 0, 0, 1>>
     assert {0.5, -1073} == FloatPP.Digits.frexp(small_denorm)
   end
 
   test "test frexp(large denormalized number)" do
     # 2.22507385850720088902e-308
-    <<large_denorm::float>> = <<0,15,255,255,255,255,255,255>>
+    <<large_denorm::float>> = <<0, 15, 255, 255, 255, 255, 255, 255>>
     assert {0.99999999999999978, -1022} == FloatPP.Digits.frexp(large_denorm)
   end
 
   test "test frexp(small normalized number)" do
     # 2.22507385850720138309e-308
-    <<small_norm::float>> = <<0,16,0,0,0,0,0,0>>
+    <<small_norm::float>> = <<0, 16, 0, 0, 0, 0, 0, 0>>
     assert {0.5, -1021} == FloatPP.Digits.frexp(small_norm)
   end
 
   test "test frexp(large normalized number)" do
     # 1.79769313486231570815e+308
-    <<large_norm::float>> = <<127,239,255,255,255,255,255,255>>
+    <<large_norm::float>> = <<127, 239, 255, 255, 255, 255, 255, 255>>
     assert {0.99999999999999989, 1024} == FloatPP.Digits.frexp(large_norm)
   end
-
 end
-

--- a/test/float_pp_test.exs
+++ b/test/float_pp_test.exs
@@ -4,22 +4,22 @@ defmodule FloatPPTest do
 
   test "Simple float test" do
     assert "1.2" ==
-            FloatPP.to_string(1.2)
+             FloatPP.to_string(1.2)
   end
 
   test "small float" do
     assert "0.000001" ==
-            FloatPP.to_string(0.000001)
+             FloatPP.to_string(0.000001)
   end
 
   test "small negative float" do
     assert "-0.000001" ==
-            FloatPP.to_string(-0.000001)
+             FloatPP.to_string(-0.000001)
   end
 
   test "large float test" do
     assert "10000.0" ==
-            FloatPP.to_string(10000.0)
+             FloatPP.to_string(10000.0)
   end
 
   ############################################################################
@@ -123,9 +123,7 @@ defmodule FloatPPTest do
     assert "1000.0" == FloatPP.to_string(999.9999, options)
   end
 
-
   ############################################################################
-
 
   test "test to_digits(zero)" do
     assert "0.0" == FloatPP.to_string(0.0)
@@ -141,65 +139,79 @@ defmodule FloatPPTest do
 
   test "test to_digits(small denormalized number)" do
     # 4.94065645841246544177e-324
-    <<small_denorm::float>> = <<0,0,0,0,0,0,0,1>>
-    assert "4.9406564584124654e-324" == FloatPP.to_string(small_denorm, %{scientific: true, compact: true})
+    <<small_denorm::float>> = <<0, 0, 0, 0, 0, 0, 0, 1>>
+
+    assert "4.9406564584124654e-324" ==
+             FloatPP.to_string(small_denorm, %{scientific: true, compact: true})
   end
 
   test "test to_digits(large denormalized number)" do
     # 2.22507385850720088902e-308
-    <<large_denorm::float>> = <<0,15,255,255,255,255,255,255>>
-    assert "2.225073858507201e-308" == FloatPP.to_string(large_denorm, %{scientific: true, compact: true})
+    <<large_denorm::float>> = <<0, 15, 255, 255, 255, 255, 255, 255>>
+
+    assert "2.225073858507201e-308" ==
+             FloatPP.to_string(large_denorm, %{scientific: true, compact: true})
   end
 
   test "test to_digits(small normalized number)" do
     # 2.22507385850720138309e-308
-    <<small_norm::float>> = <<0,16,0,0,0,0,0,0>>
-    assert "2.2250738585072014e-308" == FloatPP.to_string(small_norm, %{scientific: true, compact: true})
+    <<small_norm::float>> = <<0, 16, 0, 0, 0, 0, 0, 0>>
+
+    assert "2.2250738585072014e-308" ==
+             FloatPP.to_string(small_norm, %{scientific: true, compact: true})
   end
 
   test "test to_digits(large normalized number)" do
     # 1.79769313486231570815e+308
-    <<large_norm::float>> = <<127,239,255,255,255,255,255,255>>
-    assert "1.7976931348623157e+308" == FloatPP.to_string(large_norm, %{scientific: true, compact: true})
-  end
+    <<large_norm::float>> = <<127, 239, 255, 255, 255, 255, 255, 255>>
 
+    assert "1.7976931348623157e+308" ==
+             FloatPP.to_string(large_norm, %{scientific: true, compact: true})
+  end
 
   ############################################################################
 
-
   test "test format_decimal scientific" do
-    assert  "7.00000000000000000000e+00" =
-            FloatPP.format_decimal({["7"], 1, true}, %{scientific: 20, compact: false}) |> IO.iodata_to_binary
+    assert "7.00000000000000000000e+00" =
+             FloatPP.format_decimal({["7"], 1, true}, %{scientific: 20, compact: false})
+             |> IO.iodata_to_binary()
 
-    assert  "7.0e+00" =
-            FloatPP.format_decimal({["7"], 1, true}, %{scientific: 20, compact: true}) |> IO.iodata_to_binary
+    assert "7.0e+00" =
+             FloatPP.format_decimal({["7"], 1, true}, %{scientific: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "7.0e+01" =
-            FloatPP.format_decimal({["7"], 2, true}, %{scientific: 20, compact: true}) |> IO.iodata_to_binary
+    assert "7.0e+01" =
+             FloatPP.format_decimal({["7"], 2, true}, %{scientific: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "7.0e-02" =
-            FloatPP.format_decimal({["7"], -1, true}, %{scientific: 20, compact: true}) |> IO.iodata_to_binary
+    assert "7.0e-02" =
+             FloatPP.format_decimal({["7"], -1, true}, %{scientific: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "7.0e-10" =
-            FloatPP.format_decimal({["7"], -9, true}, %{scientific: 20, compact: true}) |> IO.iodata_to_binary
+    assert "7.0e-10" =
+             FloatPP.format_decimal({["7"], -9, true}, %{scientific: 20, compact: true})
+             |> IO.iodata_to_binary()
   end
 
   test "test format_decimal decimal" do
-    assert  "7.00000000000000000000" =
-            FloatPP.format_decimal({["7"], 1, true}, %{decimals: 20, compact: false}) |> IO.iodata_to_binary
+    assert "7.00000000000000000000" =
+             FloatPP.format_decimal({["7"], 1, true}, %{decimals: 20, compact: false})
+             |> IO.iodata_to_binary()
 
-    assert  "7.0" =
-            FloatPP.format_decimal({["7"], 1, true}, %{decimals: 20, compact: true}) |> IO.iodata_to_binary
+    assert "7.0" =
+             FloatPP.format_decimal({["7"], 1, true}, %{decimals: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "70.0" =
-            FloatPP.format_decimal({["7"], 2, true}, %{decimals: 20, compact: true}) |> IO.iodata_to_binary
+    assert "70.0" =
+             FloatPP.format_decimal({["7"], 2, true}, %{decimals: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "0.07" =
-            FloatPP.format_decimal({["7"], -1, true}, %{decimals: 20, compact: true}) |> IO.iodata_to_binary
+    assert "0.07" =
+             FloatPP.format_decimal({["7"], -1, true}, %{decimals: 20, compact: true})
+             |> IO.iodata_to_binary()
 
-    assert  "0.0000000007" =
-            FloatPP.format_decimal({["7"], -9, true}, %{decimals: 20, compact: true}) |> IO.iodata_to_binary
+    assert "0.0000000007" =
+             FloatPP.format_decimal({["7"], -9, true}, %{decimals: 20, compact: true})
+             |> IO.iodata_to_binary()
   end
-
-
 end

--- a/test/rounding_test.exs
+++ b/test/rounding_test.exs
@@ -69,4 +69,12 @@ defmodule RoundingTest do
     assert -1.21 == floor(-1.206, 2)
   end
 
+  test "round with 0 decimals of a number between 0 and one" do
+    assert 1.0 == round(0.959999999999809, 0)
+  end
+
+  test "rounding to less than the precision of the number returns 0" do
+    assert 0.0 = round(1.235e-4, 3, :half_even)
+  end
+
 end

--- a/test/rounding_test.exs
+++ b/test/rounding_test.exs
@@ -4,7 +4,7 @@ defmodule RoundingTest do
   def round(number, precision \\ 0, rounding \\ :half_up) do
     number
     |> FloatPP.to_string(%{compact: false, decimals: precision, rounding: rounding})
-    |> String.to_float
+    |> String.to_float()
   end
 
   def ceil(number, precision \\ 0) do
@@ -76,5 +76,4 @@ defmodule RoundingTest do
   test "rounding to less than the precision of the number returns 0" do
     assert 0.0 = round(1.235e-4, 3, :half_even)
   end
-
 end


### PR DESCRIPTION
Minor code edits in `float_pp.ex` to remove the unsafe variables about which Elixir 1.3 complains.  All tests still run green.

(and thanks for this code - its exactly what I need for my cldr project!)
